### PR TITLE
Update for compatibility with GWT 2.7+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ bin
 .project
 .classpath
 .settings
+*.iml
+dependency-reduced-pom.xml

--- a/javaee-websocket-gwt-rpc-sample/pom.xml
+++ b/javaee-websocket-gwt-rpc-sample/pom.xml
@@ -20,13 +20,13 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.google.gwt</groupId>
+			<groupId>${gwt.groupId}</groupId>
 			<artifactId>gwt-servlet</artifactId>
 		</dependency>
 
 		<!-- Depend on gwt-user for compilation only -->
 		<dependency>
-			<groupId>com.google.gwt</groupId>
+			<groupId>${gwt.groupId}</groupId>
 			<artifactId>gwt-user</artifactId>
 			<scope>provided</scope>
 		</dependency>
@@ -36,7 +36,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
+				<groupId>${gwt.plugin.groupId}</groupId>
 				<artifactId>gwt-maven-plugin</artifactId>
 				<executions>
 					<execution>

--- a/javaee-websocket-gwt-rpc/pom.xml
+++ b/javaee-websocket-gwt-rpc/pom.xml
@@ -17,7 +17,7 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.google.gwt</groupId>
+			<groupId>${gwt.groupId}</groupId>
 			<artifactId>gwt-servlet</artifactId>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,10 @@
 	<properties>
 		<webbit.version>0.4.15</webbit.version>
 
-		<gwt.version>2.6.1</gwt.version>
-		<gwt.plugin.version>2.6.1</gwt.plugin.version>
+		<gwt.groupId>com.google.gwt</gwt.groupId>
+		<gwt.plugin.groupId>org.codehaus.mojo</gwt.plugin.groupId>
+		<gwt.version>2.7.0</gwt.version>
+		<gwt.plugin.version>2.7.0</gwt.plugin.version>
 	</properties>
 
 	<dependencyManagement>
@@ -28,7 +30,7 @@
 			</dependency>
 
 			<dependency>
-				<groupId>com.google.gwt</groupId>
+				<groupId>${gwt.groupId}</groupId>
 				<artifactId>gwt-servlet</artifactId>
 				<version>${gwt.version}</version>
 			</dependency>
@@ -36,7 +38,7 @@
 			<!-- This dep causes gwt-m-p to warn about complex dependencies, ignore 
 				it -->
 			<dependency>
-				<groupId>com.google.gwt</groupId>
+				<groupId>${gwt.groupId}</groupId>
 				<artifactId>gwt-dev</artifactId>
 				<version>${gwt.version}</version>
 				<scope>provided</scope>
@@ -44,7 +46,7 @@
 
 			<!-- Depend on gwt-user, -dev for compilation only -->
 			<dependency>
-				<groupId>com.google.gwt</groupId>
+				<groupId>${gwt.groupId}</groupId>
 				<artifactId>gwt-user</artifactId>
 				<version>${gwt.version}</version>
 			</dependency>
@@ -61,17 +63,17 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
-					<groupId>org.codehaus.mojo</groupId>
+					<groupId>${gwt.plugin.groupId}</groupId>
 					<artifactId>gwt-maven-plugin</artifactId>
 					<version>${gwt.plugin.version}</version>
 					<dependencies>
 						<dependency>
-							<groupId>com.google.gwt</groupId>
+							<groupId>${gwt.groupId}</groupId>
 							<artifactId>gwt-user</artifactId>
 							<version>${gwt.version}</version>
 						</dependency>
 						<dependency>
-							<groupId>com.google.gwt</groupId>
+							<groupId>${gwt.groupId}</groupId>
 							<artifactId>gwt-dev</artifactId>
 							<version>${gwt.version}</version>
 						</dependency>

--- a/rpc-client-common/pom.xml
+++ b/rpc-client-common/pom.xml
@@ -14,12 +14,12 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>com.google.gwt</groupId>
+			<groupId>${gwt.groupId}</groupId>
 			<artifactId>gwt-user</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.google.gwt</groupId>
+			<groupId>${gwt.groupId}</groupId>
 			<artifactId>gwt-dev</artifactId>
 			<scope>provided</scope>
 		</dependency>

--- a/rpc-client-common/src/main/java/com/colinalworth/gwt/websockets/rebind/ServerCreator.java
+++ b/rpc-client-common/src/main/java/com/colinalworth/gwt/websockets/rebind/ServerCreator.java
@@ -100,14 +100,14 @@ public class ServerCreator {
 
 		//Find all types that may go over the wire
 		// Collect the types the server will send to the client using the Client interface
-		SerializableTypeOracleBuilder serverSerializerBuilder = new SerializableTypeOracleBuilder(logger, context.getPropertyOracle(), context);
+		SerializableTypeOracleBuilder serverSerializerBuilder = new SerializableTypeOracleBuilder(logger, context);
 		appendMethodParameters(logger, clientType, Client.class, serverSerializerBuilder);
 		// Also add the wrapper object ClientInvocation
 		serverSerializerBuilder.addRootType(logger, oracle.findType(ClientInvocation.class.getName()));
 		serverSerializerBuilder.addRootType(logger, oracle.findType(ClientCallbackInvocation.class.getName()));
 
 		// Collect the types the client will send to the server using the Server interface
-		SerializableTypeOracleBuilder clientSerializerBuilder = new SerializableTypeOracleBuilder(logger, context.getPropertyOracle(), context);
+		SerializableTypeOracleBuilder clientSerializerBuilder = new SerializableTypeOracleBuilder(logger, context);
 		appendMethodParameters(logger, this.serverType, Server.class, clientSerializerBuilder);
 		// Also add the ServerInvocation wrapper
 		clientSerializerBuilder.addRootType(logger, oracle.findType(ServerInvocation.class.getName()));

--- a/webbit-gwt-rpc-sample/pom.xml
+++ b/webbit-gwt-rpc-sample/pom.xml
@@ -22,13 +22,13 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.google.gwt</groupId>
+			<groupId>${gwt.groupId}</groupId>
 			<artifactId>gwt-servlet</artifactId>
 		</dependency>
 
 		<!-- Depend on gwt-user for compilation only -->
 		<dependency>
-			<groupId>com.google.gwt</groupId>
+			<groupId>${gwt.groupId}</groupId>
 			<artifactId>gwt-user</artifactId>
 			<scope>provided</scope>
 		</dependency>
@@ -42,7 +42,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
+				<groupId>${gwt.plugin.groupId}</groupId>
 				<artifactId>gwt-maven-plugin</artifactId>
 				<executions>
 					<execution>

--- a/webbit-gwt-rpc/pom.xml
+++ b/webbit-gwt-rpc/pom.xml
@@ -24,14 +24,14 @@
 		<!-- This dep causes gwt-m-p to warn about complex dependencies, ignore 
 			it -->
 		<dependency>
-			<groupId>com.google.gwt</groupId>
+			<groupId>${gwt.groupId}</groupId>
 			<artifactId>gwt-dev</artifactId>
 			<scope>provided</scope>
 		</dependency>
 
 		<!-- Depend on gwt-user, -dev for compilation only -->
 		<dependency>
-			<groupId>com.google.gwt</groupId>
+			<groupId>${gwt.groupId}</groupId>
 			<artifactId>gwt-user</artifactId>
 		</dependency>
 


### PR DESCRIPTION
Only a small API change for Gwt support.

I also updated the version numbers, and made it simple to change which Gwt fork is used.  I have it defaulting to canonical, but I can swap it as needed in case I need a different fork.  I can remove that change if you don't want it to pollute master.