### PR TITLE
Ignore url parameters when creating wss or ws urls

### DIFF
--- a/rpc-client-common/src/main/java/com/colinalworth/gwt/websockets/client/impl/ServerBuilderImpl.java
+++ b/rpc-client-common/src/main/java/com/colinalworth/gwt/websockets/client/impl/ServerBuilderImpl.java
@@ -7,14 +7,17 @@ import com.google.gwt.user.client.Window;
 
 public abstract class ServerBuilderImpl<S extends Server<S, ?>> implements ServerBuilder<S> {
 	private String url;
-	private UrlBuilder urlBuilder = Window.Location.createUrlBuilder();
+	private UrlBuilder urlBuilder;
 	private ConnectionErrorHandler errorHandler;
 
 	/**
 	 *
 	 */
 	public ServerBuilderImpl() {
-		urlBuilder.setProtocol("https".equals(Window.Location.getProtocol()) ? "wss": "ws").setHash(null);
+		urlBuilder = new UrlBuilder();
+		urlBuilder.setProtocol("https".equals(Window.Location.getProtocol()) ? "wss": "ws");
+      		urlBuilder.setHost(Window.Location.getHost());
+		urlBuilder.setPath(Window.Location.getPath());
 	}
 
 	@Override


### PR DESCRIPTION
otherwise ws urls will contain url parameters like 'gwt.codesvr' which cannot be resolved.

invalid example url:
ws://localhost:8800/test?gwt.codesvr=127.0.1.1
